### PR TITLE
Fix benchmarks

### DIFF
--- a/value_vs_pointer_01_test.go
+++ b/value_vs_pointer_01_test.go
@@ -8,28 +8,28 @@ type ValueVsPointer struct {
 	Filed1 int
 }
 
+//go:noinline
 func returnValue(i ValueVsPointer) ValueVsPointer {
 	return i
 }
 
+//go:noinline
 func returnPointer(i *ValueVsPointer) *ValueVsPointer {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount01(b *testing.B) {
+	v := &ValueVsPointer{Filed1: 1}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer(&ValueVsPointer{Filed1: 1})
-		if v.Filed1 != 1 {
-			b.Fail()
-		}
+		v = returnPointer(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount01(b *testing.B) {
+	v := ValueVsPointer{Filed1: 1}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue(ValueVsPointer{Filed1: 1})
-		if v.Filed1 != 1 {
-			b.Fail()
-		}
+		v = returnValue(v)
 	}
 }

--- a/value_vs_pointer_02_test.go
+++ b/value_vs_pointer_02_test.go
@@ -9,38 +9,34 @@ type ValueVsPointer02 struct {
 	Filed2 int
 }
 
+//go:noinline
 func returnValue02(i ValueVsPointer02) ValueVsPointer02 {
 	return i
 }
 
+//go:noinline
 func returnPointer02(i *ValueVsPointer02) *ValueVsPointer02 {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount02(b *testing.B) {
+	v := &ValueVsPointer02{
+		Filed1: 1,
+		Filed2: 2,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer02(
-			&ValueVsPointer02{
-				Filed1: 1,
-				Filed2: 2,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 {
-			b.Fail()
-		}
+		v = returnPointer02(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount02(b *testing.B) {
+	v := ValueVsPointer02{
+		Filed1: 1,
+		Filed2: 2,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue02(
-			ValueVsPointer02{
-				Filed1: 1,
-				Filed2: 2,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 {
-			b.Fail()
-		}
+		v = returnValue02(v)
 	}
 }

--- a/value_vs_pointer_03_test.go
+++ b/value_vs_pointer_03_test.go
@@ -10,40 +10,36 @@ type ValueVsPointer03 struct {
 	Filed3 int
 }
 
+//go:noinline
 func returnValue03(i ValueVsPointer03) ValueVsPointer03 {
 	return i
 }
 
+//go:noinline
 func returnPointer03(i *ValueVsPointer03) *ValueVsPointer03 {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount03(b *testing.B) {
+	v := &ValueVsPointer03{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer03(
-			&ValueVsPointer03{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 {
-			b.Fail()
-		}
+		v = returnPointer03(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount03(b *testing.B) {
+	v := ValueVsPointer03{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue03(
-			ValueVsPointer03{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 {
-			b.Fail()
-		}
+		v = returnValue03(v)
 	}
 }

--- a/value_vs_pointer_04_test.go
+++ b/value_vs_pointer_04_test.go
@@ -11,42 +11,38 @@ type ValueVsPointer04 struct {
 	Filed4 int
 }
 
+//go:noinline
 func returnValue04(i ValueVsPointer04) ValueVsPointer04 {
 	return i
 }
 
+//go:noinline
 func returnPointer04(i *ValueVsPointer04) *ValueVsPointer04 {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount04(b *testing.B) {
+	v := &ValueVsPointer04{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer04(
-			&ValueVsPointer04{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 {
-			b.Fail()
-		}
+		v = returnPointer04(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount04(b *testing.B) {
+	v := ValueVsPointer04{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue04(
-			ValueVsPointer04{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 {
-			b.Fail()
-		}
+		v = returnValue04(v)
 	}
 }

--- a/value_vs_pointer_05_test.go
+++ b/value_vs_pointer_05_test.go
@@ -12,46 +12,40 @@ type ValueVsPointer05 struct {
 	Filed5 int
 }
 
+//go:noinline
 func returnValue05(i ValueVsPointer05) ValueVsPointer05 {
 	return i
 }
 
+//go:noinline
 func returnPointer05(i *ValueVsPointer05) *ValueVsPointer05 {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount05(b *testing.B) {
+	v := &ValueVsPointer05{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+		Filed5: 5,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer05(
-			&ValueVsPointer05{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-				Filed5: 5,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 ||
-			v.Filed5 != 5 {
-			b.Fail()
-		}
+		v = returnPointer05(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount05(b *testing.B) {
+	v := ValueVsPointer05{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+		Filed5: 5,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue05(
-			ValueVsPointer05{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-				Filed5: 5,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 ||
-			v.Filed5 != 5 {
-			b.Fail()
-		}
+		v = returnValue05(v)
 	}
 }

--- a/value_vs_pointer_08_test.go
+++ b/value_vs_pointer_08_test.go
@@ -15,53 +15,46 @@ type ValueVsPointer08 struct {
 	Filed8 int
 }
 
+//go:noinline
 func returnValue08(i ValueVsPointer08) ValueVsPointer08 {
 	return i
 }
 
+//go:noinline
 func returnPointer08(i *ValueVsPointer08) *ValueVsPointer08 {
 	return i
 }
 
 func BenchmarkUsePointerFieldCount08(b *testing.B) {
+	v := &ValueVsPointer08{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+		Filed5: 5,
+		Filed6: 6,
+		Filed7: 7,
+		Filed8: 8,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnPointer08(
-			&ValueVsPointer08{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-				Filed5: 5,
-				Filed6: 6,
-				Filed7: 7,
-				Filed8: 8,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 ||
-			v.Filed5 != 5 || v.Filed6 != 6 || v.Filed7 != 7 || v.Filed8 != 8 {
-			b.Fail()
-		}
+		v = returnPointer08(v)
 	}
 }
 
 func BenchmarkUseValueFieldCount08(b *testing.B) {
+	v := ValueVsPointer08{
+		Filed1: 1,
+		Filed2: 2,
+		Filed3: 3,
+		Filed4: 4,
+		Filed5: 5,
+		Filed6: 6,
+		Filed7: 7,
+		Filed8: 8,
+	}
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		v := returnValue08(
-			ValueVsPointer08{
-				Filed1: 1,
-				Filed2: 2,
-				Filed3: 3,
-				Filed4: 4,
-				Filed5: 5,
-				Filed6: 6,
-				Filed7: 7,
-				Filed8: 8,
-			},
-		)
-		if v.Filed1 != 1 || v.Filed2 != 2 || v.Filed3 != 3 || v.Filed4 != 4 ||
-			v.Filed5 != 5 || v.Filed6 != 6 || v.Filed7 != 7 || v.Filed8 != 8 {
-
-			b.Fail()
-		}
+		v = returnValue08(v)
 	}
 }


### PR DESCRIPTION
`go tool compile -S` で確認したところ、既存のベンチマークでは値渡しとポインタ渡しの差を正しく計測できないと思います。

* 01-04 がインライン化されており、最適化の影響からかループ内の処理が消えている
* ループ内で変数初期化、比較を行っているためポインタ渡しの結果もフィールド数に応じて増加している

これらを解決するために以下のような変更をしています。

* `returnValue` と `returnPointer` に `//go:noinline` を指定してインライン化を阻止し、常に値渡し・ポインタ渡しする
* 変数初期化をループ外に出して、初期化後にタイマーをリセットする
* 比較処理を削除

私の環境では以下のようになりました。
（恐らく使用している CPU が古いため `MOVUPS` が使用される 05 以降極端に遅くなってます）

```
$ go test -bench .
goos: linux
goarch: amd64
BenchmarkUsePointerFieldCount01-6       1000000000               2.97 ns/op
BenchmarkUseValueFieldCount01-6         1000000000               2.82 ns/op
BenchmarkUsePointerFieldCount02-6       500000000                2.94 ns/op
BenchmarkUseValueFieldCount02-6         500000000                3.38 ns/op
BenchmarkUsePointerFieldCount03-6       500000000                3.82 ns/op
BenchmarkUseValueFieldCount03-6         300000000                4.44 ns/op
BenchmarkUsePointerFieldCount04-6       1000000000               2.77 ns/op
BenchmarkUseValueFieldCount04-6         300000000                4.25 ns/op
BenchmarkUsePointerFieldCount05-6       1000000000               2.79 ns/op
BenchmarkUseValueFieldCount05-6         100000000               16.4 ns/op
BenchmarkUsePointerFieldCount08-6       1000000000               2.79 ns/op
BenchmarkUseValueFieldCount08-6         100000000               21.0 ns/op
PASS
ok      _/home/oda/repos/value_vs_pointer       28.993s
```